### PR TITLE
Fix: Update sql-expression.py

### DIFF
--- a/05_running_basic_queries/sql-expression.py
+++ b/05_running_basic_queries/sql-expression.py
@@ -5,7 +5,11 @@ from sqlalchemy import (
 # executing the instructions from our localhost "chinook" db
 db = create_engine("postgresql:///chinook")
 
-meta = MetaData(db)
+# Create MetaData object
+meta = MetaData()
+
+# Bind the engine to the MetaData object
+meta.bind = db
 
 # create variable for "Artist" table
 artist_table = Table(
@@ -43,7 +47,7 @@ with db.connect() as connection:
     # select_query = artist_table.select()
 
     # Query 2 - select only the "Name" column from the "Artist" table
-    # select_query = artist_table.select().with_only_columns([artist_table.c.Name])
+    # select_query = artist_table.select().with_only_columns(artist_table.c.Name)
 
     # Query 3 - select only 'Queen' from the "Artist" table
     # select_query = artist_table.select().where(artist_table.c.Name == "Queen")


### PR DESCRIPTION
### Two error fixes:
- MetaData(db) 
    - The error occurs because you're passing a database engine object to the MetaData constructor, but it expects a string for the schema argument.
- Query 2: with_only_columns([artist_table.c.Name]) 
    - This error is occurring because of a change in the SQLAlchemy API. The with_only_columns() method now expects its arguments to be passed as individual positional arguments rather than as a list.